### PR TITLE
UpdateResourceCommand should extend DefaultCommand

### DIFF
--- a/src/LiteCQRS/Plugin/CRUD/Model/Commands/UpdateResourceCommand.php
+++ b/src/LiteCQRS/Plugin/CRUD/Model/Commands/UpdateResourceCommand.php
@@ -4,7 +4,7 @@ namespace LiteCQRS\Plugin\CRUD\Model\Commands;
 
 use LiteCQRS\DefaultCommand;
 
-class UpdateResourceCommand
+class UpdateResourceCommand extends DefaultCommand
 {
     public $class;
     public $id;


### PR DESCRIPTION
Reading through LiteCQRS\Plugin\SymfonyBundle\Controller\CRUDHelper I noticed UpdateResourceCommand was not extending the DefaultCommand
