### PR TITLE
Add EventListener for GenerateSchemaEvent

### DIFF
--- a/src/LiteCQRS/Plugin/SymfonyBundle/EventListener/SchemaListener.php
+++ b/src/LiteCQRS/Plugin/SymfonyBundle/EventListener/SchemaListener.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace LiteCQRS\Plugin\SymfonyBundle\EventListener;
+
+use LiteCQRS\Plugin\Doctrine\EventStore\TableEventStore;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+
+class SchemaListener
+{
+    public function __construct(TableEventStore $store)
+    {
+        $this->store = $store;
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $args)
+    {
+        $this->store->addEventsToSchema($args->getSchema());
+    }
+}

--- a/src/LiteCQRS/Plugin/SymfonyBundle/Resources/config/dbal_event_store.xml
+++ b/src/LiteCQRS/Plugin/SymfonyBundle/Resources/config/dbal_event_store.xml
@@ -5,12 +5,18 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="litecqrs.doctrine.table_event_store.class">LiteCQRS\Plugin\Doctrine\EventStore\TableEventStore</parameter>
+        <parameter key="litecqrs.dbal.schema_listener.class">LiteCQRS\Plugin\SymfonyBundle\EventListener\SchemaListener</parameter>
     </parameters>
 
     <services>
         <service id="litecqrs.doctrine.event_store" class="%litecqrs.doctrine.table_event_store.class%">
             <argument type="service" id="doctrine.dbal.default_connection" />
             <argument type="service" id="litecqrs.serializer" />
+        </service>
+
+        <service id="litecqrs.dbal.schema_listener" class="%litecqrs.dbal.schema_listener.class%" public="false">
+            <tag name="doctrine.event_listener" event="postGenerateSchema" lazy="true" connection="default" />
+            <argument type="service" id="litecqrs.doctrine.event_store" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
Done in the same way that SecurityBundle does for ACL. Make it easier to maintain and Doctrine will not drop it everytime we run update.
