### PR TITLE
DomainObjectChanged's second argument is now optional.

### DIFF
--- a/src/LiteCQRS/DomainObjectChanged.php
+++ b/src/LiteCQRS/DomainObjectChanged.php
@@ -19,7 +19,7 @@ class DomainObjectChanged implements DomainEvent
 
     private $eventName;
 
-    public function __construct($eventName, array $args)
+    public function __construct($eventName, array $args = array())
     {
         $this->eventName = $eventName;
         foreach ($args as $property => $value) {


### PR DESCRIPTION
The reason behind this changed is that i have found i mostly
just send the id to the event handlers and they will fetch the
newest aggregate and take appropiate action (write to the read tables).

And that id is given through the $event->getAggregateId() that is stored in a Message on the Event.
