### PR TITLE
Decouple AggregateResource

### DIFF
--- a/src/LiteCQRS/AggregateRepositoryInterface.php
+++ b/src/LiteCQRS/AggregateRepositoryInterface.php
@@ -15,22 +15,22 @@ interface AggregateRepositoryInterface
      * @param string $class
      * @param mixed $id
      *
-     * @return AggregateRootInterface
+     * @return object
      */
     public function find($class, $id);
 
     /**
      * Add aggregate root to repository and schedule for persistence.
      *
-     * @param AggregateRootInterface $object
+     * @param object $object
      */
-    public function add(AggregateRootInterface $object);
+    public function add($object);
 
     /**
      * Schedule aggregate root for removal
      *
-     * @param AggregateRootInterface $object
+     * @param object $object
      */
-    public function remove(AggregateRootInterface $object);
+    public function remove($object);
 }
 

--- a/src/LiteCQRS/Plugin/CRUD/CrudCreatable.php
+++ b/src/LiteCQRS/Plugin/CRUD/CrudCreatable.php
@@ -17,13 +17,6 @@ trait CrudCreatable
 
     protected function applyResourceCreated(ResourceCreatedEvent $event)
     {
-        $properties = array_keys(get_class_vars($this));
-
-        foreach ($event->data as $key => $value) {
-            if (in_array($key, $properties)) {
-                $this->$key = $value;
-            }
-        }
+        $this->updateDomain($event);
     }
 }
-

--- a/src/LiteCQRS/Plugin/CRUD/CrudUpdatable.php
+++ b/src/LiteCQRS/Plugin/CRUD/CrudUpdatable.php
@@ -17,13 +17,6 @@ trait CrudUpdatable
 
     protected function applyResourceUpdated(ResourceUpdatedEvent $event)
     {
-        $properties = array_keys(get_class_vars($this));
-
-        foreach ($event->data as $key => $value) {
-            if (in_array($key, $properties)) {
-                $this->$key = $value;
-            }
-        }
+        $this->updateDomain($event);
     }
 }
-

--- a/src/LiteCQRS/Plugin/CRUD/DomainAggregateResource.php
+++ b/src/LiteCQRS/Plugin/CRUD/DomainAggregateResource.php
@@ -3,11 +3,9 @@
 namespace LiteCQRS\Plugin\CRUD;
 
 use LiteCQRS\AggregateRoot;
-use LiteCQRS\Plugin\CRUD\Model\Events\ResourceCreatedEvent;
-use LiteCQRS\Plugin\CRUD\Model\Events\ResourceUpdatedEvent;
-use LiteCQRS\Plugin\CRUD\Model\Events\ResourceDeletedEvent;
 
-use LiteCQRS\DomainEvent;
+use LiteCQRS\Plugin\CRUD\Updater\AccessFilter\UniversalFilter;
+use LiteCQRS\Plugin\CRUD\Updater\ReflectionBasedUpdater;
 
 /**
  * Aggregate Resource Base class that helps you implement
@@ -22,11 +20,16 @@ use LiteCQRS\DomainEvent;
  * list of properties that are allowed to be updated using
  * the {@see getAccessibleProperties()} method.
  */
-abstract class AggregateResource extends AggregateRoot
+class DomainAggregateResource extends AggregateRoot
 {
-    use DomainAsAggregate;
+    use DomainAsProperty;
     use CrudCreatable;
     use CrudDeletable;
     use CrudUpdatable;
-}
 
+    public function __construct()
+    {
+        $this->filter  = new UniversalFilter;
+        $this->updater = new ReflectionBasedUpdater;
+    }
+}

--- a/src/LiteCQRS/Plugin/CRUD/DomainAsAggregate.php
+++ b/src/LiteCQRS/Plugin/CRUD/DomainAsAggregate.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LiteCQRS\Plugin\CRUD;
+
+use LiteCQRS\Plugin\CRUD\Model\Events\DefaultDataEvent;
+
+trait DomainAsAggregate
+{
+    protected function getAccessibleProperties()
+    {
+        return array_keys(get_class_vars($this));
+    }
+
+    /**
+     * Update domain data
+     *
+     * @param Model\Events\DefaultDataEvent $event
+     */
+    protected function updateDomain(DefaultDataEvent $event)
+    {
+        $properties = $this->getAccessibleProperties();
+        foreach ($event->data as $key => $value) {
+            if (in_array($key, $properties)) {
+                $this->$key = $value;
+            }
+        }
+    }
+}

--- a/src/LiteCQRS/Plugin/CRUD/DomainAsProperty.php
+++ b/src/LiteCQRS/Plugin/CRUD/DomainAsProperty.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace LiteCQRS\Plugin\CRUD;
+
+use LiteCQRS\Plugin\CRUD\Model\Events\DefaultDataEvent;
+
+use LiteCQRS\Plugin\CRUD\Updater\AccessFilter\PropertyFilter;
+use LiteCQRS\Plugin\CRUD\Updater\PropertyUpdater;
+
+trait DomainAsProperty
+{
+    /** @var PropertyUpdater */
+    protected $updater;
+
+    /** @var PropertyFilter */
+    protected $filter;
+
+    /** @var object */
+    protected $domain;
+
+    /**
+     * Sets domain
+     *
+     * @param object $domain
+     *
+     * @return DomainAsProperty
+     */
+    public function setDomain($domain)
+    {
+        $this->domain = $domain;
+
+        return $this;
+    }
+
+    /**
+     * Sets domain
+     *
+     * @return object
+     */
+    public function getDomain()
+    {
+        return $this->domain;
+    }
+
+    /**
+     * Update domain data
+     *
+     * @param Model\Events\DefaultDataEvent $event
+     */
+    protected function updateDomain(DefaultDataEvent $event)
+    {
+        $data = $this->filter->filter($this->domain, $event->data);
+        $this->updater->update($this->domain, $data);
+    }
+}

--- a/src/LiteCQRS/Plugin/CRUD/Model/Events/DefaultDataEvent.php
+++ b/src/LiteCQRS/Plugin/CRUD/Model/Events/DefaultDataEvent.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace LiteCQRS\Plugin\CRUD\Model\Events;
+
+use LiteCQRS\DefaultDomainEvent;
+
+abstract class DefaultDataEvent extends DefaultDomainEvent
+{
+    public $data = array();
+}

--- a/src/LiteCQRS/Plugin/CRUD/Model/Events/ResourceCreatedEvent.php
+++ b/src/LiteCQRS/Plugin/CRUD/Model/Events/ResourceCreatedEvent.php
@@ -2,12 +2,9 @@
 
 namespace LiteCQRS\Plugin\CRUD\Model\Events;
 
-use LiteCQRS\DefaultDomainEvent;
-
-class ResourceCreatedEvent extends DefaultDomainEvent
+class ResourceCreatedEvent extends DefaultDataEvent
 {
     public $class;
     public $id;
-    public $data = array();
 }
 

--- a/src/LiteCQRS/Plugin/CRUD/Model/Events/ResourceUpdatedEvent.php
+++ b/src/LiteCQRS/Plugin/CRUD/Model/Events/ResourceUpdatedEvent.php
@@ -2,12 +2,8 @@
 
 namespace LiteCQRS\Plugin\CRUD\Model\Events;
 
-use LiteCQRS\DefaultDomainEvent;
-
-class ResourceUpdatedEvent extends DefaultDomainEvent
+class ResourceUpdatedEvent extends DefaultDataEvent
 {
     public $class;
     public $id;
-    public $data = array();
 }
-

--- a/src/LiteCQRS/Plugin/CRUD/Updater/AccessFilter/InterfaceFilter.php
+++ b/src/LiteCQRS/Plugin/CRUD/Updater/AccessFilter/InterfaceFilter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace LiteCQRS\Plugin\CRUD\Updater\AccessFilter;
+
+use LiteCQRS\Plugin\CRUD\Updater\AccessFilter\Model\PublicPropertiesMap;
+
+class InterfaceFilter implements PropertyFilter
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function filter($domain, array $data)
+    {
+        return $domain instanceof PublicPropertiesMap
+            ? array_intersect_assoc($data, $domain->getPublicPropertiesMap())
+            : array();
+    }
+}

--- a/src/LiteCQRS/Plugin/CRUD/Updater/AccessFilter/Model/PublicPropertiesMap.php
+++ b/src/LiteCQRS/Plugin/CRUD/Updater/AccessFilter/Model/PublicPropertiesMap.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace LiteCQRS\Plugin\CRUD\Updater\AccessFilter\Model;
+
+interface PublicPropertiesMap
+{
+    /**
+     * Get writable properties map
+     *
+     * @return string[]
+     */
+    function getPublicPropertiesMap();
+}

--- a/src/LiteCQRS/Plugin/CRUD/Updater/AccessFilter/PropertyFilter.php
+++ b/src/LiteCQRS/Plugin/CRUD/Updater/AccessFilter/PropertyFilter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LiteCQRS\Plugin\CRUD\Updater\AccessFilter;
+
+interface PropertyFilter
+{
+    /**
+     * Property access filter
+     *
+     * @param object  $domain
+     * @param array   $data domain property key => data
+     *
+     * @return array filtered data
+     */
+    function filter($domain, array $data);
+}

--- a/src/LiteCQRS/Plugin/CRUD/Updater/AccessFilter/ReflectionFilter.php
+++ b/src/LiteCQRS/Plugin/CRUD/Updater/AccessFilter/ReflectionFilter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LiteCQRS\Plugin\CRUD\Updater\AccessFilter;
+
+class ReflectionFilter implements PropertyFilter
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function filter($domain, array $data)
+    {
+        $objectRef = new \ReflectionObject($domain);
+
+        $filteredData = array();
+
+        foreach ($data as $propertyName => $value) {
+            if ($objectRef->hasProperty($propertyName)) {
+                $filteredData[$propertyName] = $value;
+            }
+        }
+
+        return $filteredData;
+    }
+}

--- a/src/LiteCQRS/Plugin/CRUD/Updater/AccessFilter/SetterFilter.php
+++ b/src/LiteCQRS/Plugin/CRUD/Updater/AccessFilter/SetterFilter.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LiteCQRS\Plugin\CRUD\Updater\AccessFilter;
+
+class SetterFilter implements PropertyFilter
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function filter($domain, array $data)
+    {
+        $filteredData = array();
+
+        foreach ($data as $propertyName => $value) {
+            $method = 'set' . ucfirst($propertyName);
+            if (method_exists($domain, $method)) {
+                $filteredData[$propertyName] = $value;
+            }
+        }
+
+        return $filteredData;
+    }
+}

--- a/src/LiteCQRS/Plugin/CRUD/Updater/AccessFilter/UniversalFilter.php
+++ b/src/LiteCQRS/Plugin/CRUD/Updater/AccessFilter/UniversalFilter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace LiteCQRS\Plugin\CRUD\Updater\AccessFilter;
+
+class UniversalFilter implements PropertyFilter
+{
+    protected $reflection;
+    protected $setter;
+    protected $interface;
+
+    public function __construct()
+    {
+        $this->reflection = new ReflectionFilter;
+        $this->setter     = new SetterFilter;
+        $this->interface  = new InterfaceFilter;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function filter($domain, array $data)
+    {
+        $filteredData = $this->interface->filter($domain, $data);
+
+        if (!$filteredData) {
+            $filteredData = $this->setter->filter($domain, $data);
+        }
+
+        if (!$filteredData) {
+            $filteredData = $this->reflection->filter($domain, $data);
+        }
+
+        return $filteredData;
+    }
+}

--- a/src/LiteCQRS/Plugin/CRUD/Updater/PropertyUpdater.php
+++ b/src/LiteCQRS/Plugin/CRUD/Updater/PropertyUpdater.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace LiteCQRS\Plugin\CRUD\Updater;
+
+interface PropertyUpdater
+{
+    /**
+     * Update domain model
+     *
+     * @param object $domain
+     * @param array  $data   new data, key-value model properties
+     */
+    function update($domain, array $data);
+}

--- a/src/LiteCQRS/Plugin/CRUD/Updater/ReflectionBasedUpdater.php
+++ b/src/LiteCQRS/Plugin/CRUD/Updater/ReflectionBasedUpdater.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LiteCQRS\Plugin\CRUD\Updater;
+
+class ReflectionBasedUpdater implements PropertyUpdater
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function update($domain, array $data)
+    {
+        $objectRef = new \ReflectionObject($domain);
+        foreach ($data as $key => $value) {
+            $propertyRef = $objectRef->getProperty($key);
+            $protected   = $propertyRef->isProtected() || $propertyRef->isPrivate();
+
+            if ($protected) {
+                $propertyRef->setAccessible(true);
+            }
+
+            $propertyRef->setValue($domain, $value);
+
+            if ($protected) {
+                $propertyRef->setAccessible(false);
+            }
+        }
+    }
+}

--- a/src/LiteCQRS/Plugin/CRUD/Updater/SetterBasedUpdater.php
+++ b/src/LiteCQRS/Plugin/CRUD/Updater/SetterBasedUpdater.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace LiteCQRS\Plugin\CRUD\Updater;
+
+class SetterBasedUpdater implements PropertyUpdater
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function update($domain, array $data)
+    {
+        foreach ($data as $key => $value) {
+            $method = 'set' . ucfirst($key);
+            $domain->$method($value);
+        }
+    }
+}

--- a/src/LiteCQRS/Plugin/Doctrine/ORMRepository.php
+++ b/src/LiteCQRS/Plugin/Doctrine/ORMRepository.php
@@ -3,7 +3,6 @@
 namespace LiteCQRS\Plugin\Doctrine;
 
 use LiteCQRS\AggregateRepositoryInterface;
-use LiteCQRS\AggregateRootInterface;
 use Doctrine\ORM\EntityManager;
 
 class ORMRepository implements AggregateRepositoryInterface
@@ -20,12 +19,12 @@ class ORMRepository implements AggregateRepositoryInterface
         return $this->entityManager->find($class, $id);
     }
 
-    public function add(AggregateRootInterface $object)
+    public function add($object)
     {
         $this->entityManager->persist($object);
     }
 
-    public function remove(AggregateRootInterface $object)
+    public function remove($object)
     {
         $this->entityManager->remove($object);
     }

--- a/src/LiteCQRS/Plugin/DoctrineCouchDB/CouchDBRepository.php
+++ b/src/LiteCQRS/Plugin/DoctrineCouchDB/CouchDBRepository.php
@@ -3,7 +3,6 @@
 namespace LiteCQRS\Plugin\DoctrineCouchDB;
 
 use LiteCQRS\AggregateRepositoryInterface;
-use LiteCQRS\AggregateRootInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 
 class CouchDBRepository implements AggregateRepositoryInterface
@@ -20,12 +19,12 @@ class CouchDBRepository implements AggregateRepositoryInterface
         return $this->objectManager->find($class, $id);
     }
 
-    public function add(AggregateRootInterface $object)
+    public function add($object)
     {
         $this->objectManager->persist($object);
     }
 
-    public function remove(AggregateRootInterface $object)
+    public function remove($object)
     {
         $this->objectManager->remove($object);
     }


### PR DESCRIPTION
Why AggregateResource so strongly coupled with domain model ?

https://github.com/beberlei/litecqrs-php/blob/master/src/LiteCQRS/Plugin/CRUD/AggregateResource.php#L23

I think, inherit domain model from AggregateResource is not a good idea. Better to design without LiteCQRS dependency and incapsulate all in CRUDHelper. In this way we can keep old behaviour  with setter/getter anemic domain, we can safely remove LiteCQRS library and refactor only small pieces of code (controller helper).

See LiteCQRS\Plugin\CRUD\CRUDCommandService. In my version, domain model is clear, but DomainAggregateResource decorates it.

About domain model accessible properties detection and update. There is a few ways to detect accessible properties in our domain. Map method in domain (getAccessibleProperties), setter method_exists, reflection property detection, annotations, config.

I realize first 3 methods in LiteCQRS\Plugin\CRUD\Updater\Filter components. UniversalFilter chains all of them and filters $event->data.

Filtered data from event can be writed through domain setters (LiteCQRS\Plugin\CRUD\Updater\SetterBasedUpdater), or injected directly to domain properties through reflection (LiteCQRS\Plugin\CRUD\Updater\ReflectionBasedUpdater). In reflection based updater we can unprotect domain property store value from event data and protect it back.

I incapsulate some components to traits, DomainAggregateResource - uses DomainAsProperty trait, and AggregateResource - uses DomainAsAggregate.

Some limitations (or not): our repository now is not AggregateRepositoryInterface, it stores any domain object.
