### PR TITLE
Update Silex Plugin to work with master

### DIFF
--- a/src/LiteCQRS/Plugin/Silex/Provider/LiteCQRSServiceProvider.php
+++ b/src/LiteCQRS/Plugin/Silex/Provider/LiteCQRSServiceProvider.php
@@ -41,7 +41,7 @@ class LiteCQRSServiceProvider implements \Silex\ServiceProviderInterface
         });
 
         $app['lite_cqrs.event_message_handler'] = $app->share(function (Application $app) {
-            return new EventMessageHandlerFactory($app['lite_cqrs.event_message_bus'], $app['lite_cqrs.event_queue']);
+            return new EventMessageHandlerFactory($app['event_message_bus'], $app['lite_cqrs.event_queue']);
         });
 
         $app['lite_cqrs.command_proxy_factories'] = $app->share(function (Application $app) {

--- a/src/LiteCQRS/Plugin/Silex/Provider/LiteCQRSServiceProvider.php
+++ b/src/LiteCQRS/Plugin/Silex/Provider/LiteCQRSServiceProvider.php
@@ -2,8 +2,11 @@
 
 namespace LiteCQRS\Plugin\Silex\Provider;
 
-use LiteCQRS\Plugin\Silex;
-use LiteCQRS\Bus;
+use LiteCQRS\Plugin\Silex\ApplicationEventBus;
+use LiteCQRS\Plugin\Silex\ApplicationCommandBus;
+use LiteCQRS\Bus\IdentityMap\EventProviderQueue;
+use LiteCQRS\Bus\IdentityMap\SimpleIdentityMap;
+use LiteCQRS\Bus\EventMessageHandlerFactory;
 use Silex\Application;
 
 /**
@@ -22,24 +25,31 @@ class LiteCQRSServiceProvider implements \Silex\ServiceProviderInterface
         $app['lite_cqrs.event_handlers']          = array();
 
         $app['command_bus'] = $app->share(function (Application $app) {
-            return new Silex\ApplicationCommandBus($app, $app['lite_cqrs.command_proxy_factories']);
+            return new ApplicationCommandBus($app, $app['lite_cqrs.command_proxy_factories']);
+        });
+
+        $app['event_message_bus'] = $app->share(function (Application $app) {
+            return new ApplicationEventBus($app, $app['lite_cqrs.event_proxy_factories']);
+        });
+
+        $app['lite_cqrs.event_queue'] = $app->share(function (Application $app) {
+            return new EventProviderQueue($app['lite_cqrs.identity_map']);
         });
 
         $app['lite_cqrs.identity_map'] = $app->share(function () {
-            return new Bus\IdentityMap\SimpleIdentityMap();
-        });
-
-        $app['lite_cqrs.event_message_bus'] = $app->share(function (Application $app) {
-            return new Silex\ApplicationEventBus($app, $app['lite_cqrs.event_proxy_factories']);
+            return new SimpleIdentityMap();
         });
 
         $app['lite_cqrs.event_message_handler'] = $app->share(function (Application $app) {
-            return new Bus\EventMessageHandlerFactory($app['lite_cqrs.event_message_bus'], $app['lite_cqrs.identity_map']);
+            return new EventMessageHandlerFactory($app['lite_cqrs.event_message_bus'], $app['lite_cqrs.event_queue']);
         });
 
         $app['lite_cqrs.command_proxy_factories'] = $app->share(function (Application $app) {
             return array($app['lite_cqrs.event_message_handler']);
         });
+
+        // Keep backwards compatibility
+        $app['lite_cqrs.event_message_bus'] = $app->raw('event_message_bus');
     }
 
     /**


### PR DESCRIPTION
Also change lite_cqrs.event_message_bus to event_message bus. This is
done because it is a main entry point for LiteCQRS just like the
command_bus is.
