### PR TITLE
Fix create() and update() methods for Crud traits, missed in [PR-32]

### DIFF
--- a/src/LiteCQRS/Plugin/CRUD/CrudCreatable.php
+++ b/src/LiteCQRS/Plugin/CRUD/CrudCreatable.php
@@ -11,7 +11,7 @@ trait CrudCreatable
         $this->apply(new ResourceCreatedEvent(array(
             'class' => get_class($this),
             'id'    => $this->id,
-            'data'  => $this->data,
+            'data'  => $data,
         )));
     }
 

--- a/src/LiteCQRS/Plugin/CRUD/CrudUpdatable.php
+++ b/src/LiteCQRS/Plugin/CRUD/CrudUpdatable.php
@@ -11,7 +11,7 @@ trait CrudUpdatable
         $this->apply(new ResourceUpdatedEvent(array(
             'class' => get_class($this),
             'id'    => $this->id,
-            'data'  => $this->data,
+            'data'  => $data,
         )));
     }
 


### PR DESCRIPTION
The changes in [PR-32] were made to AggregateResource.php but were not sumarily applied to the Crud[Creatable|Updatable] companion methods
