### PR TITLE
Raise event from aggregate root

### DIFF
--- a/src/LiteCQRS/AggregateRoot.php
+++ b/src/LiteCQRS/AggregateRoot.php
@@ -31,6 +31,11 @@ abstract class AggregateRoot implements AggregateRootInterface
     protected function apply(DomainEvent $event)
     {
         $this->executeEvent($event);
+        $this->raise($event);
+    }
+
+    protected function raise(DomainEvent $event)
+    {
         $event->getMessageHeader()->setAggregate($this);
         $this->appliedEvents[] = $event;
     }

--- a/src/LiteCQRS/Plugin/CRUD/CrudCreatable.php
+++ b/src/LiteCQRS/Plugin/CRUD/CrudCreatable.php
@@ -11,7 +11,7 @@ trait CrudCreatable
         $this->apply(new ResourceCreatedEvent(array(
             'class' => get_class($this),
             'id'    => $this->id,
-            'data'  => $this->data,
+            'data'  => $data,
         )));
     }
 

--- a/src/LiteCQRS/Plugin/CRUD/CrudUpdatable.php
+++ b/src/LiteCQRS/Plugin/CRUD/CrudUpdatable.php
@@ -11,7 +11,7 @@ trait CrudUpdatable
         $this->apply(new ResourceUpdatedEvent(array(
             'class' => get_class($this),
             'id'    => $this->id,
-            'data'  => $this->data,
+            'data'  => $data,
         )));
     }
 


### PR DESCRIPTION
```
Entity objects must either extend AggregateRoot or DomainEventProvider.
Since the usage of Doctrine and/or CRUD plugins requires the use of
AggregateRoot, there is no ability to call raise() to execute a
DomainObjectChanged notice. which means that we cannot have event
handlers listening for DomainObjectChanged.

Using apply() does not allow us to send DomainObjectChanged objects
since it would subsequently then require an applyDomainObjectChanged
method, which is unneeded.

apply() and raise() do the exact same thing other than the apply()
method calling $this->executeEvent($event), thus it's a simple matter
to add raise() to AggregateRoot, which then enables us to do

$this->raise(new DomainObjectChanged("ChangeEmail", array("email" => $email, "oldEmail" => $this->email)));

from our Entity objects which extend AggregateRoot so that they can
use the Doctrine and CRUD plugins.
```
