### PR TITLE
Implement DomainEventProviderInterface, deprecate AggregateRepositoryInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Also to synchronize the events to event message bus you can use the DoctrineIden
 
 - ``LiteCQRS\Plugin\Doctrine\DoctrineIdentityMap``
 
-It also ships with an implementation of ``AggregateRepositoryInterface`` wrapping
+It also ships with an implementation of ``DomainEventProviderRepositoryInterface`` wrapping
 the EntityManager:
 
 - ``LiteCQRS\Plugin\Doctrine\ORMRepository``
@@ -339,7 +339,7 @@ You can enable/disable the different plugins by adding the following to your con
         couchdb_event_store:    true
         couchdb_odm:            true
 
-Please refer to the [SymfonyExample.md](https://github.com/beberlei/litecqrs-php/blob/master/example/SymfonyExample.md) 
+Please refer to the [SymfonyExample.md](https://github.com/beberlei/litecqrs-php/blob/master/example/SymfonyExample.md)
 document for a full demonstration of using LiteCQRS from within a Symfony2 project.
 
 ### Swiftmailer

--- a/src/LiteCQRS/AggregateRepositoryInterface.php
+++ b/src/LiteCQRS/AggregateRepositoryInterface.php
@@ -3,6 +3,8 @@
 namespace LiteCQRS;
 
 /**
+ * @deprecated Use DomainEventProviderRepositoryInterface instead
+ *
  * Very simple aggregate repository that you can
  * use for reusable behaviors, independent of the underlying
  * persistence storage or event sourcing

--- a/src/LiteCQRS/DomainEventProviderRepositoryInterface.php
+++ b/src/LiteCQRS/DomainEventProviderRepositoryInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace LiteCQRS;
+
+/**
+ * Very simple domain event provider repository that you can
+ * use for reusable behaviors, independent of the underlying
+ * persistence storage or event sourcing
+ */
+interface DomainEventProviderRepositoryInterface
+{
+    /**
+     * Find an event provider object by class name and id
+     *
+     * @param string $class
+     * @param mixed $id
+     *
+     * @return EventProviderInterface
+     */
+    public function find($class, $id);
+
+    /**
+     * Add event provider object to repository and schedule for persistence.
+     *
+     * @param EventProviderInterface $object
+     */
+    public function add(EventProviderInterface $object);
+
+    /**
+     * Schedule event provider object for removal
+     *
+     * @param EventProviderInterface $object
+     */
+    public function remove(EventProviderInterface $object);
+}
+

--- a/src/LiteCQRS/Plugin/CRUD/CRUDCommandService.php
+++ b/src/LiteCQRS/Plugin/CRUD/CRUDCommandService.php
@@ -2,7 +2,7 @@
 
 namespace LiteCQRS\Plugin\CRUD;
 
-use LiteCQRS\AggregateRepositoryInterface;
+use LiteCQRS\DomainEventProviderRepositoryInterface;
 use LiteCQRS\Plugin\CRUD\Model\Commands\CreateResourceCommand;
 use LiteCQRS\Plugin\CRUD\Model\Commands\UpdateResourceCommand;
 use LiteCQRS\Plugin\CRUD\Model\Commands\DeleteResourceCommand;
@@ -15,7 +15,7 @@ class CRUDCommandService
 {
     private $repository;
 
-    public function __construct(AggregateRepositoryInterface $repository)
+    public function __construct(DomainEventProviderRepositoryInterface $repository)
     {
         $this->repository = $repository;
     }

--- a/src/LiteCQRS/Plugin/Doctrine/ORMRepository.php
+++ b/src/LiteCQRS/Plugin/Doctrine/ORMRepository.php
@@ -2,11 +2,11 @@
 
 namespace LiteCQRS\Plugin\Doctrine;
 
-use LiteCQRS\AggregateRepositoryInterface;
-use LiteCQRS\AggregateRootInterface;
+use LiteCQRS\DomainEventProviderRepositoryInterface;
+use LiteCQRS\EventProviderInterface;
 use Doctrine\ORM\EntityManager;
 
-class ORMRepository implements AggregateRepositoryInterface
+class ORMRepository implements DomainEventProviderRepositoryInterface
 {
     private $entityManager;
 
@@ -20,14 +20,13 @@ class ORMRepository implements AggregateRepositoryInterface
         return $this->entityManager->find($class, $id);
     }
 
-    public function add(AggregateRootInterface $object)
+    public function add(EventProviderInterface $object)
     {
         $this->entityManager->persist($object);
     }
 
-    public function remove(AggregateRootInterface $object)
+    public function remove(EventProviderInterface $object)
     {
         $this->entityManager->remove($object);
     }
 }
-

--- a/src/LiteCQRS/Plugin/DoctrineCouchDB/CouchDBRepository.php
+++ b/src/LiteCQRS/Plugin/DoctrineCouchDB/CouchDBRepository.php
@@ -2,11 +2,11 @@
 
 namespace LiteCQRS\Plugin\DoctrineCouchDB;
 
-use LiteCQRS\AggregateRepositoryInterface;
-use LiteCQRS\AggregateRootInterface;
+use LiteCQRS\DomainEventProviderRepositoryInterface;
+use LiteCQRS\EventProviderInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 
-class CouchDBRepository implements AggregateRepositoryInterface
+class CouchDBRepository implements DomainEventProviderRepositoryInterface
 {
     private $objectManager;
 
@@ -20,12 +20,12 @@ class CouchDBRepository implements AggregateRepositoryInterface
         return $this->objectManager->find($class, $id);
     }
 
-    public function add(AggregateRootInterface $object)
+    public function add(EventProviderInterface $object)
     {
         $this->objectManager->persist($object);
     }
 
-    public function remove(AggregateRootInterface $object)
+    public function remove(EventProviderInterface $object)
     {
         $this->objectManager->remove($object);
     }

--- a/src/LiteCQRS/Plugin/JMSSerializer/AggregateRootHandler.php
+++ b/src/LiteCQRS/Plugin/JMSSerializer/AggregateRootHandler.php
@@ -3,7 +3,7 @@
 namespace LiteCQRS\Plugin\JMSSerializer;
 
 use LiteCQRS\Bus\IdentityMap\IdentityMapInterface;
-use LiteCQRS\AggregateRepositoryInterface;
+use LiteCQRS\DomainEventProviderRepositoryInterface;
 
 use JMS\SerializerBundle\Serializer\VisitorInterface;
 use JMS\SerializerBundle\Metadata\ClassMetadata;
@@ -21,7 +21,7 @@ class AggregateRootHandler implements DeserializationHandlerInterface, Serializa
     private $enabled = false;
     private $identityMap;
 
-    public function __construct(IdentityMapInterface $identityMap, AggregateRepositoryInterface $repository)
+    public function __construct(IdentityMapInterface $identityMap, DomainEventProviderRepositoryInterface $repository)
     {
         $this->identityMap = $identityMap;
         $this->repository  = $repository;

--- a/tests/LiteCQRS/Plugin/CRUD/AggregateResourceTest.php
+++ b/tests/LiteCQRS/Plugin/CRUD/AggregateResourceTest.php
@@ -1,9 +1,10 @@
 <?php
 
 namespace LiteCQRS\Plugin\CRUD;
-use LiteCQRS\AggregateRepositoryInterface;
-use LiteCQRS\AggregateRootInterface;
+
 use LiteCQRS\DomainEvent;
+use LiteCQRS\DomainEventProviderRepositoryInterface;
+use LiteCQRS\EventProviderInterface;
 use LiteCQRS\Plugin\CRUD\Model\Commands\CreateResourceCommand;
 use LiteCQRS\Plugin\CRUD\Model\Commands\UpdateResourceCommand;
 
@@ -62,7 +63,7 @@ class DummyObject extends AggregateResource
     }
 }
 
-class DummyRepo implements AggregateRepositoryInterface
+class DummyRepo implements DomainEventProviderRepositoryInterface
 {
     public $addObject;
 
@@ -79,12 +80,12 @@ class DummyRepo implements AggregateRepositoryInterface
         return $this->updateObject;
     }
 
-    public function add(AggregateRootInterface $object)
+    public function add(EventProviderInterface $object)
     {
         $this->addObject = $object;
     }
 
-    public function remove(AggregateRootInterface $object)
+    public function remove(EventProviderInterface $object)
     {
     }
 }

--- a/tests/LiteCQRS/Plugin/JMSSerializer/SerializerTest.php
+++ b/tests/LiteCQRS/Plugin/JMSSerializer/SerializerTest.php
@@ -28,14 +28,14 @@ use LiteCQRS\Plugin\JMSSerializer\JMSSerializer;
 
 use LiteCQRS\DefaultDomainEvent;
 use LiteCQRS\AggregateRoot;
-use LiteCQRS\AggregateRepositoryInterface;
+use LiteCQRS\DomainEventProviderRepositoryInterface;
 
 class SerializerTest extends \PHPUnit_Framework_TestCase
 {
     public function testSerializeEvent()
     {
         $identityMap = $this->getMock('LiteCQRS\Bus\IdentityMap\IdentityMapInterface');
-        $repository = $this->getMock('LiteCQRS\AggregateRepositoryInterface');
+        $repository = $this->getMock('LiteCQRS\DomainEventProviderRepositoryInterface');
         $serializer = $this->createJmsSerializer($identityMap, $repository);
 
         $event = new SomeEvent(array("root" => new SomeAggregateRoot()));
@@ -49,7 +49,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $data = '{"root":{"aggregate_type":"LiteCQRS\\\\Plugin\\\\JMSSerializer\\\\SomeAggregateRoot","aggregate_id":1}}';
 
         $identityMap = $this->getMock('LiteCQRS\Bus\IdentityMap\IdentityMapInterface');
-        $repository = $this->getMock('LiteCQRS\AggregateRepositoryInterface');
+        $repository = $this->getMock('LiteCQRS\DomainEventProviderRepositoryInterface');
         $repository->expects($this->once())
                    ->method('find')
                    ->with($this->equalTo('LiteCQRS\Plugin\JMSSerializer\SomeAggregateRoot'), $this->equalTo(1))


### PR DESCRIPTION
Based on my [discussion](https://github.com/beberlei/litecqrs-php/pull/40#discussion_r5235241) with @beberlei, implement a DomainEventProviderInterface which uses EventProviderInterface in the type hints and deprecate AggregateRepositoryInterface in place of the new interface
