### PR TITLE
Add missing apply() method to Crud trait classes

### DIFF
--- a/src/LiteCQRS/Plugin/CRUD/CrudCreatable.php
+++ b/src/LiteCQRS/Plugin/CRUD/CrudCreatable.php
@@ -15,6 +15,13 @@ trait CrudCreatable
         )));
     }
 
+    protected function apply(DomainEvent $event)
+    {
+        $this->applyResourceCreated($event);
+        $event->getMessageHeader()->setAggregate($this);
+        $this->appliedEvents[] = $event;
+    }
+
     protected function applyResourceCreated(ResourceCreatedEvent $event)
     {
         $properties = array_keys(get_class_vars($this));
@@ -26,4 +33,3 @@ trait CrudCreatable
         }
     }
 }
-

--- a/src/LiteCQRS/Plugin/CRUD/CrudCreatable.php
+++ b/src/LiteCQRS/Plugin/CRUD/CrudCreatable.php
@@ -24,12 +24,23 @@ trait CrudCreatable
 
     protected function applyResourceCreated(ResourceCreatedEvent $event)
     {
-        $properties = array_keys(get_class_vars($this));
+        $properties = $this->getAccessibleProperties();
 
         foreach ($event->data as $key => $value) {
             if (in_array($key, $properties)) {
                 $this->$key = $value;
             }
         }
+    }
+
+    /**
+     * Return an array of properties that are allowed to change
+     * through the create() and update() methods.
+     *
+     * @return array
+     */
+    protected function getAccessibleProperties()
+    {
+        return array_keys(get_class_vars(get_class($this)));
     }
 }

--- a/src/LiteCQRS/Plugin/CRUD/CrudCreatable.php
+++ b/src/LiteCQRS/Plugin/CRUD/CrudCreatable.php
@@ -2,6 +2,7 @@
 
 namespace LiteCQRS\Plugin\CRUD;
 
+use LiteCQRS\DomainEvent;
 use LiteCQRS\Plugin\CRUD\Model\Events\ResourceCreatedEvent;
 
 trait CrudCreatable

--- a/src/LiteCQRS/Plugin/CRUD/CrudDeletable.php
+++ b/src/LiteCQRS/Plugin/CRUD/CrudDeletable.php
@@ -11,8 +11,14 @@ trait CrudDeletable
         $this->apply(new ResourceDeletedEvent());
     }
 
+    protected function apply(DomainEvent $event)
+    {
+        $this->applyResourceDeleted($event);
+        $event->getMessageHeader()->setAggregate($this);
+        $this->appliedEvents[] = $event;
+    }
+
     protected function applyResourceDeleted(ResourceDeletedEvent $event)
     {
     }
 }
-

--- a/src/LiteCQRS/Plugin/CRUD/CrudDeletable.php
+++ b/src/LiteCQRS/Plugin/CRUD/CrudDeletable.php
@@ -2,6 +2,7 @@
 
 namespace LiteCQRS\Plugin\CRUD;
 
+use LiteCQRS\DomainEvent;
 use LiteCQRS\Plugin\CRUD\Model\Events\ResourceDeletedEvent;
 
 trait CrudDeletable

--- a/src/LiteCQRS/Plugin/CRUD/CrudUpdatable.php
+++ b/src/LiteCQRS/Plugin/CRUD/CrudUpdatable.php
@@ -24,12 +24,23 @@ trait CrudUpdatable
 
     protected function applyResourceUpdated(ResourceUpdatedEvent $event)
     {
-        $properties = array_keys(get_class_vars($this));
+        $properties = $this->getAccessibleProperties();
 
         foreach ($event->data as $key => $value) {
             if (in_array($key, $properties)) {
                 $this->$key = $value;
             }
         }
+    }
+
+    /**
+     * Return an array of properties that are allowed to change
+     * through the create() and update() methods.
+     *
+     * @return array
+     */
+    protected function getAccessibleProperties()
+    {
+        return array_keys(get_class_vars(get_class($this)));
     }
 }

--- a/src/LiteCQRS/Plugin/CRUD/CrudUpdatable.php
+++ b/src/LiteCQRS/Plugin/CRUD/CrudUpdatable.php
@@ -2,6 +2,7 @@
 
 namespace LiteCQRS\Plugin\CRUD;
 
+use LiteCQRS\DomainEvent;
 use LiteCQRS\Plugin\CRUD\Model\Events\ResourceUpdatedEvent;
 
 trait CrudUpdatable

--- a/src/LiteCQRS/Plugin/CRUD/CrudUpdatable.php
+++ b/src/LiteCQRS/Plugin/CRUD/CrudUpdatable.php
@@ -15,6 +15,13 @@ trait CrudUpdatable
         )));
     }
 
+    protected function apply(DomainEvent $event)
+    {
+        $this->applyResourceUpdated($event);
+        $event->getMessageHeader()->setAggregate($this);
+        $this->appliedEvents[] = $event;
+    }
+
     protected function applyResourceUpdated(ResourceUpdatedEvent $event)
     {
         $properties = array_keys(get_class_vars($this));
@@ -26,4 +33,3 @@ trait CrudUpdatable
         }
     }
 }
-


### PR DESCRIPTION
The methods in the Plugin/CRUD/Crud\* trait classes call out
to an apply method (which in turn calls the trait's applyResource*
methods), which does not exist in the trait class definition.

This means that the CRUD plugin cannot be used with entity objects
that extend DomainEventProvider, as that class doesn't provide an
apply method. Instead, Aggreagte Resource would need to be extended,
which extends AggregateRoot, which means the entity would no longer
have access to raise() events.

Since the Crud traits are near duplicate methods to versions in
CRUD/AggregateResource and AggregateRoot anyway, there's no point in
using the traits, when you could just extend AggregateResource instead.

But for when AggregateResource cannot be the extended class, the
traits are needed, therefore the entire call chain needs to be
available, so that we don't violate DRY by re-implementing apply() in
every Entity object that extends DomainEventProvider but needs the
create/update/delete crud traits
