### PR TITLE
OptimisticLockingEventStore now remembers eventData

### DIFF
--- a/src/LiteCQRS/EventStore/OptimisticLocking/OptimisticLockingEventStore.php
+++ b/src/LiteCQRS/EventStore/OptimisticLocking/OptimisticLockingEventStore.php
@@ -35,7 +35,12 @@ class OptimisticLockingEventStore implements EventStore
 
         $events = array();
 
+        if (!isset($this->eventsData[$streamData->getId()])) {
+            $this->eventsData[$streamData->getId()] = [];
+        }
+
         foreach ($streamData->getEventData() as $eventData) {
+            $this->eventsData[$streamData->getId()][] = $eventData;
             $events[] = $this->serializer->fromArray($eventData);
         }
 


### PR DESCRIPTION
By setting `$this->eventData[$stream->getId()]` to the current eventData in `find()`, `commit()` actually knows about the eventData.
