### PR TITLE
Check if metadriver is available before adding

### DIFF
--- a/src/LiteCQRS/Plugin/SymfonyBundle/DependencyInjection/Compiler/JMSSerializerPass.php
+++ b/src/LiteCQRS/Plugin/SymfonyBundle/DependencyInjection/Compiler/JMSSerializerPass.php
@@ -10,7 +10,7 @@ class JMSSerializerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if ( ! $container->has('serializer')) {
+        if ( ! $container->has('serializer') || !$container->has('litecqrs.serializer.metadata_driver') ) {
             return;
         }
 


### PR DESCRIPTION
Currently if you don't enable the JMS serializer but have it installed it fails on not having the litecqrs.serializer.metadata_driver available. 
